### PR TITLE
whyred: rootdir: init.qcom.rc: Remove rmt_storage and tftp_server services definition from rootdir

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -515,16 +515,6 @@ service irsc_util /vendor/bin/irsc_util "/vendor/etc/sec_config"
     user root
     oneshot
 
-service vendor.rmt_storage /vendor/bin/rmt_storage
-    class core
-    user root
-    shutdown critical
-    ioprio rt 0
-
-service vendor.tftp_server /vendor/bin/tftp_server
-   class core
-   user root
-
 service vendor.ipacm /system/vendor/bin/ipacm
     class main
     user radio


### PR DESCRIPTION


* caf moved that to proper rc files with newer blobs.

Signed-off-by: adi8900 <adrianszymanski242@gmail.com>